### PR TITLE
add buildinfo plugin published via bintray on the yetu account.

### DIFF
--- a/app/com/yetu/controlcenter/controllers/Health.scala
+++ b/app/com/yetu/controlcenter/controllers/Health.scala
@@ -1,17 +1,11 @@
 package com.yetu.controlcenter.controllers
 
-import com.yetu.controlcenter.models.HealthObject
-import play.api.libs.json.{JsValue, Json, JsString, JsObject}
 import play.api.mvc.{Action, Controller}
 
 object Health extends Controller {
 
   def check = Action {
-    //TODO: publish buildinfo plugin and fix the commented out line
-    // include in plugins.sbt
-    //    Ok(com.yetu.BuildInfo.toJson)
-
-    Ok(Json.toJson(new HealthObject("alive")))
+    Ok(com.yetu.BuildInfo.toJson)
   }
 
 

--- a/app/com/yetu/controlcenter/models/HealthObject.scala
+++ b/app/com/yetu/controlcenter/models/HealthObject.scala
@@ -1,9 +1,0 @@
-package com.yetu.controlcenter.models
-
-import play.api.libs.json.Json
-
-case class HealthObject(status: String = "alive")
-
-object HealthObject {
-  implicit val format = Json.format[HealthObject]
-}

--- a/buildInfo.sbt
+++ b/buildInfo.sbt
@@ -1,0 +1,35 @@
+import java.util.{Calendar, TimeZone}
+
+import sbtbuildinfo.Plugin._
+import sbt.Keys._
+
+//
+// Settings related to the sbt-buildinfo plugin
+//-----------------------------------------------
+
+buildInfoSettings
+
+buildInfoPackage := organization.value
+
+sourceGenerators in Compile <+= buildInfo
+
+lazy val gitTag = Process("git tag --contains HEAD").lines.headOption.getOrElse("")
+
+lazy val lastCommit = Process("git log --pretty=oneline  -1").lines.head
+
+buildInfoKeys ++= Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, organization)
+
+buildInfoKeys ++= Seq[BuildInfoKey](
+  BuildInfoKey.action("tag") {
+    gitTag
+  },
+  BuildInfoKey.action("status") {
+    "alive"
+  },
+  BuildInfoKey.action("commit") {
+    lastCommit
+  },
+  BuildInfoKey.action("buildTime") {
+    String.format("%tFT%<tRZ", Calendar.getInstance(TimeZone.getTimeZone("Z")))
+  }
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.1.1")
+
+addSbtPlugin("com.yetu" % "sbt-buildinfo" % "0.3.5")

--- a/test/com/yetu/controlcenter/routes/HealthCheckSpec.scala
+++ b/test/com/yetu/controlcenter/routes/HealthCheckSpec.scala
@@ -14,6 +14,8 @@ class HealthCheckSpec extends BaseRoutesSpec {
       val Some(result) = route(FakeRequest(GET, healthUrl))
       status(result) mustEqual (OK)
       contentAsString(result) must include("alive")
+      contentAsString(result) must include("com.yetu")
+      contentAsString(result) must include("controlcenter")
     }
   }
 }


### PR DESCRIPTION
`/health` now returns:

```
{"organization":"com.yetu", "name":"controlcenter", "commit":"b63304fda6ddd97f98a0d49ac9f4faed7930fb77 add buildinfo plugin published via bintray on the yetu account.", "tag":"", "buildTime":"2015-03-02T12:09Z", "scalaVersion":"2.11.5", "version":"1.0.0", "status":"alive", "sbtVersion":"0.13.7"}
```
To be consistent with our other services.

Also, this com.yetu sbt-buildinfo plugin is now available without specifying any additional resolvers.