### PR TITLE
Add jscs and eslint-plugin-react

### DIFF
--- a/.eslintrc-codebase
+++ b/.eslintrc-codebase
@@ -19,6 +19,10 @@
         "unicodeCodePointEscapes": true
     },
 
+    "plugins": [
+      "react"
+    ],
+
     "env": {
         "browser": true
     },
@@ -63,6 +67,10 @@
         "space-unary-ops": 2,
 
         // Legacy
-        "max-len": [2, 120]
+        "max-len": [2, 120],
+
+        // React
+        // https://github.com/yannickcr/eslint-plugin-react
+        "react/jsx-quotes": [1, "single"]
     }
 }

--- a/.eslintrc-tests
+++ b/.eslintrc-tests
@@ -19,6 +19,10 @@
         "unicodeCodePointEscapes": true
     },
 
+    "plugins": [
+      "react"
+    ],
+
     "env": {
         "browser": true,
         "jasmine": true
@@ -62,6 +66,10 @@
         "space-unary-ops": 2,
 
         // Legacy
-        "max-len": [2, 120]
+        "max-len": [2, 120],
+
+        // React
+        // https://github.com/yannickcr/eslint-plugin-react
+        "react/jsx-quotes": [1, "single"]
     }
 }

--- a/jscs.json
+++ b/jscs.json
@@ -1,0 +1,3 @@
+{
+  "requireSpacesInsideObjectBrackets": "all"
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "css-loader": "^0.9.1",
     "csso": "^1.3.11",
     "eslint": "^0.15.1",
+    "eslint-plugin-react": "^1.6.1",
     "extract-text-webpack-plugin": "^0.3.8",
     "file-loader": "^0.8.1",
     "husky": "^0.6.2",
@@ -28,6 +29,7 @@
     "jasmine-reporters": "~0.2.1",
     "jasmine-sinon": "^0.4.0",
     "jsx-loader": "^0.12.2",
+    "jsxcs": "^0.2.1",
     "karma": "^0.12.28",
     "karma-chrome-launcher": "^0.1.7",
     "karma-coverage": "^0.2.7",
@@ -63,14 +65,14 @@
     "test": "npm run bundle && node ./node_modules/karma/bin/karma start ./public/app/project-setup/test/karma.conf.js --single-run",
     "tdd": "node ./node_modules/karma/bin/karma start ./public/app/project-setup/test/karma.conf.js",
     "build": "npm run clean && npm run bundle && cp -r ./public/app/* ./public/dist",
-
     "eslint-codebase": "node_modules/.bin/eslint `npm run -s js-files` -c ./.eslintrc-codebase",
     "eslint-tests": "node_modules/.bin/eslint `npm run -s test-files` -c ./.eslintrc-tests",
+    "jscs-codebase": "node_modules/.bin/jsxcs `npm run -s js-files` --config ./jscs.json --esnext",
+    "jscs-tests": "node_modules/.bin/jsxcs `npm run -s test-files` --config ./jscs.json --esnext",
     "eslint": "npm run eslint-codebase && npm run eslint-tests",
+    "jscs": "npm run jscs-codebase",
     "lint": "npm run eslint",
-
     "fonts": "fontcustom compile",
-
     "precommit": "npm run lint && npm test"
   }
 }


### PR DESCRIPTION
Even more code style checking! :joy_cat: 
* `jscs` via `jsxcs` wrapper (so that it doesn't complain about JSX); particularly this [rule](http://catatron.com/node-jscs/rules/require-spaces-inside-object-brackets/).
* a special React plugin for `eslint` (only the single-quote checking rule is enabled for now but we can turn on [more](https://github.com/yannickcr/eslint-plugin-react).

This can be safely merged, the new eslint rules only give warnings and `jscs` is configured but is not a part of the code linting process. 

If this gets merged, I'll get down to fixing all the double quotes in JSX, missing spaces in object literals and, possibly, other stuff as well :pouting_cat: 

@larsblumberg @mr-mig 