### PR TITLE
Fix/react warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "devDependencies": {
     "autoprefixer-loader": "1.1.0",
-    "babel-core": "^4.6.6",
-    "babel-loader": "^4.0.0",
+    "babel-core": "^5.1.9",
+    "babel-loader": "^5.0.0",
     "css-loader": "^0.9.1",
     "csso": "^1.3.11",
     "eslint": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "controlcenter",
   "version": "0.0.0",
   "dependencies": {
+    "classname": "0.0.0",
     "es5-shim": "^4.1.0",
     "es6-promise": "^2.0.1",
     "qwest": "^1.5.11",

--- a/public/app/app.jsx
+++ b/public/app/app.jsx
@@ -25,6 +25,6 @@ var routes = (
   </Route>
 );
 
-Router.run(routes, function runner (Handler, state) {
-  React.render(<Handler params={state.params} />, document.body);
-});
+Router.run(routes, (Handler, state) =>
+  React.render(<Handler {...state} />, document.body)
+);

--- a/public/app/common/components/controls/button/button.jsx
+++ b/public/app/common/components/controls/button/button.jsx
@@ -1,6 +1,6 @@
 var React = require('react');
 var Pure = require('react/addons').addons.PureRenderMixin;
-var cx = require('react/lib/cx');
+var cx = require('classname');
 var styleMixin = require('mixins/style-mixin');
 
 module.exports = React.createClass({

--- a/public/app/common/components/controls/switch/switch.jsx
+++ b/public/app/common/components/controls/switch/switch.jsx
@@ -1,6 +1,6 @@
 var React = require('react');
 var styleMixin = require('mixins/style-mixin');
-var cx = require('react/lib/cx');
+var cx = require('classname');
 
 var SwitchControl = React.createClass({
   mixins: [ styleMixin(require('./style.scss')) ],

--- a/public/app/common/components/form/text-input.jsx
+++ b/public/app/common/components/form/text-input.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var cx = require('react/lib/cx');
+var cx = require('classname');
 
 function ccFormInput (locals) {
   var formGroupClasses = {

--- a/public/app/common/components/icon/icon.jsx
+++ b/public/app/common/components/icon/icon.jsx
@@ -1,6 +1,6 @@
 var React = require('react');
 var Pure = require('react/addons').addons.PureRenderMixin;
-var cx = require('react/lib/cx');
+var cx = require('classname');
 var styleMixin = require('mixins/style-mixin');
 
 module.exports = React.createClass({

--- a/public/app/screens/main/main-screen.jsx
+++ b/public/app/screens/main/main-screen.jsx
@@ -31,7 +31,7 @@ var MainScreen = React.createClass({
           </div>
           <div className='row'>
             <div className='column small-13 small-offset-1'>
-              <Navigation items={this.state.navItems} orientation='horizontal'/>
+              <Navigation {...this.props} items={this.state.navItems} orientation='horizontal'/>
             </div>
           </div>
         </div>
@@ -44,11 +44,11 @@ var MainScreen = React.createClass({
               </div>
             </div>
             <div className='main-screen__nav'>
-              <Navigation items={this.state.navItems} orientation='vertical'/>
+              <Navigation {...this.props} items={this.state.navItems} orientation='vertical'/>
             </div>
           </div>
           <div className='main-screen__body-content'>
-            <RouteHandler/>
+            <RouteHandler {...this.props}/>
           </div>
         </div>
       </div>

--- a/public/app/screens/main/navigation/navigation.jsx
+++ b/public/app/screens/main/navigation/navigation.jsx
@@ -1,12 +1,11 @@
 var React = require('react'),
   cx = require('react/lib/cx'),
   Router = require('react-router'),
-  State = Router.State,
   Link = Router.Link,
   styleMixin = require('mixins/style-mixin');
 
 var Navigation = React.createClass({
-  mixins: [styleMixin(require('./style.scss')), State],
+  mixins: [styleMixin(require('./style.scss'))],
   render: function render () {
     var items = this.props.items.map(function mapper (item, i) {
 
@@ -14,7 +13,7 @@ var Navigation = React.createClass({
         'cc_navigation__link': true,
         'item': true,
         // also mark link as active, if subpath of link is opened
-        'active': this.getPath().indexOf('/' + item.linkTo) === 0
+        'active': this.props.path.indexOf('/' + item.linkTo) === 0
       });
 
       return (

--- a/public/app/screens/main/navigation/navigation.jsx
+++ b/public/app/screens/main/navigation/navigation.jsx
@@ -1,5 +1,5 @@
 var React = require('react'),
-  cx = require('react/lib/cx'),
+  cx = require('classname'),
   Router = require('react-router'),
   Link = Router.Link,
   styleMixin = require('mixins/style-mixin');

--- a/public/app/screens/main/sections/device-details/device-details.jsx
+++ b/public/app/screens/main/sections/device-details/device-details.jsx
@@ -17,8 +17,7 @@ var DeviceDetails = React.createClass({
   mixins: [
     styleMixin(require('./style.scss')),
     Reflux.connect(deviceListStore, 'deviceList'),
-    Reflux.connect(roomStore, 'rooms'),
-    Router.State
+    Reflux.connect(roomStore, 'rooms')
   ],
 
   getRoomSelectOptions: function getRoomSelectOptions () {
@@ -46,7 +45,7 @@ var DeviceDetails = React.createClass({
   },
 
   render: function render () {
-    var deviceId = this.context.router.getCurrentParams().deviceId;
+    var deviceId = this.props.params.deviceId;
     var device = this.state.deviceList.deviceById[deviceId] || {};
     var deviceProperties = device.properties || {};
     return (

--- a/public/app/screens/main/sections/device-list/devices.jsx
+++ b/public/app/screens/main/sections/device-list/devices.jsx
@@ -26,8 +26,8 @@ var DevicesSection = React.createClass({
           </div>
         </div>
         {
-          this.state.rooms.map((room) =>
-            <Room title={ room.title } />
+          this.state.rooms.map((room, index) =>
+            <Room title={room.title} key={index} />
           )
         }
       </div>

--- a/public/app/screens/main/sections/gateway-details/gateway-details.jsx
+++ b/public/app/screens/main/sections/gateway-details/gateway-details.jsx
@@ -13,8 +13,7 @@ var Icon = require('common/components/icon');
 var DeviceDetails = React.createClass({
   mixins: [
     styleMixin(require('./style.scss')),
-    Reflux.connect(gatewayStore, 'gateway'),
-    Router.State
+    Reflux.connect(gatewayStore, 'gateway')
   ],
 
   onSave: function onSave () {
@@ -52,7 +51,6 @@ var DeviceDetails = React.createClass({
           <div className='columns medium-10'>
           </div>
         </div>
-
 
         <div className='row fixed-height-1'>
           <div className='columns medium-4 padded-left'>


### PR DESCRIPTION
Fixed all the warnings from React & React-related libs:
* [Routing](https://github.com/rackt/react-router/blob/master/UPGRADE_GUIDE.md) 
* [Child key](http://facebook.github.io/react/docs/multiple-components.html#dynamic-children) usage
* Deprecated `classname` helper (see the note [here](https://facebook.github.io/react/docs/class-name-manipulation.html))

Clean console output now, yay! :smile_cat: 