### PR TITLE
Request nest access token and send it to the household API

### DIFF
--- a/app/com/yetu/controlcenter/controllers/Application.scala
+++ b/app/com/yetu/controlcenter/controllers/Application.scala
@@ -103,18 +103,15 @@ class Application @Inject() (implicit val env: Environment[User, SessionAuthenti
     val clientSecret = Play.configuration.getString("nest.clientSecret").get
     val oauthUrl = Play.configuration.getString("nest.oauthUrl").get
     val accessTokenUrl: String = s"$oauthUrl/access_token?code=$code&client_id=$clientId&client_secret=$clientSecret&grant_type=authorization_code"
-    println(accessTokenUrl)
 
     // TODO: Handle ConnectException (e.g. nest API not reachable)
     WS.url(accessTokenUrl).execute("POST").map { response =>
       if (response.status == 200) {
         // TODO: Check "state" query parameter for consistency
         val accessToken = (Json.parse(response.body) \ "access_token").asOpt[String].getOrElse("")
-        // TODO: Send access token to household API
-        println(s"Nest access token = $accessToken")
-        Redirect(s"/#/devices/add/nest/ok")
+        Redirect(s"/#/devices/add/nest/success/" + accessToken)
       } else {
-        Redirect(s"/#/devices/add/nest/failed")
+        Redirect(s"/#/devices/add/nest/failure/unknown")
       }
     }
   }

--- a/public/app/app.jsx
+++ b/public/app/app.jsx
@@ -13,8 +13,9 @@ var DeviceListSection = require('./screens/main/sections/devices');
 var DeviceDetailsSection = require('./screens/main/sections/device-details');
 var GatewayDetailsSection = require('./screens/main/sections/gateway-details');
 var AddNestSection = require('./screens/main/sections/add-nest');
+var SendNestAccessToken = require('./screens/main/sections/add-nest/send-nest-access-token');
+var NestFailure = require('./screens/main/sections/add-nest/nest-failure');
 var SettingsRegion = require('./screens/main/sections/settings');
-
 
 var routes = (
   <Route path='/' handler={MainScreen}>
@@ -22,11 +23,14 @@ var routes = (
     <Route name='devices' path='devices' handler={DeviceListSection}/>
     <Route name='gateway' path='devices/gateway' handler={GatewayDetailsSection}/>
     <Route name='device' path='devices/:deviceId' handler={DeviceDetailsSection}/>
-    <Route name='add-nest' path='devices/add/nest/:state' handler={AddNestSection}/>
+    <Route name='add-nest' path='devices/add/nest' handler={AddNestSection}>
+      <Route name='add-nest-success' path='success/:accessToken' handler={SendNestAccessToken}/>
+      <Route name='add-nest-failure' path='failure/:error' handler={NestFailure}/>
+    </Route>
     <Redirect from='/' to='devices'/>
   </Route>
 );
 
 Router.run(routes, (Handler, state) =>
-  React.render(<Handler {...state} />, document.body)
+    React.render(<Handler {...state} />, document.body)
 );

--- a/public/app/app.jsx
+++ b/public/app/app.jsx
@@ -32,5 +32,5 @@ var routes = (
 );
 
 Router.run(routes, (Handler, state) =>
-    React.render(<Handler {...state} />, document.body)
+  React.render(<Handler {...state} />, document.body)
 );

--- a/public/app/screens/main/sections/add-nest/add-nest.jsx
+++ b/public/app/screens/main/sections/add-nest/add-nest.jsx
@@ -30,11 +30,7 @@ var AddNest = React.createClass({
         </div>
         <div className='row fixed-height-1'>
           <div className='column'>
-            {
-              this.state.devicesButtonVisible
-                ? <Link to='devices'>Show devices</Link>
-                : null
-            }
+            { this.state.devicesButtonVisible && <Link to='devices'>Show devices</Link> }
           </div>
         </div>
       </div>

--- a/public/app/screens/main/sections/add-nest/add-nest.jsx
+++ b/public/app/screens/main/sections/add-nest/add-nest.jsx
@@ -1,4 +1,7 @@
 var React = require('react');
+var Router = require('react-router');
+var Link = Router.Link;
+var RouteHandler = Router.RouteHandler;
 var styleMixin = require('mixins/style-mixin');
 
 var AddNest = React.createClass({
@@ -8,18 +11,40 @@ var AddNest = React.createClass({
 
   getInitialState: function getInitialState () {
     return {
-      successState: this.props.params.state
+      devicesButtonVisible: false
     };
-  },
-
-  componentDidMount: function componentDidMount () {
-    // TODO: Send token to gateway backend if we don't do it in the backend
   },
 
   render: function render () {
     return (
-      <span>Retrieved nest access token: { this.state.successState }</span>
+      <div className='grid-14 padded'>
+        <div className='row fixed-height-3'>
+          <div className='column'>
+            <h3 className='align-text-top'>Connect nest account</h3>
+          </div>
+        </div>
+        <div className='row fixed-height-1'>
+          <div className='column'>
+            <RouteHandler onComplete={this.onComplete}/>
+          </div>
+        </div>
+        <div className='row fixed-height-1'>
+          <div className='column'>
+            {
+              this.state.devicesButtonVisible
+                ? <Link to='devices'>Show devices</Link>
+                : null
+            }
+          </div>
+        </div>
+      </div>
     );
+  },
+
+  onComplete: function onComplete () {
+    if (!this.state.devicesButtonVisible) {
+      this.setState({ devicesButtonVisible: true });
+    }
   }
 });
 

--- a/public/app/screens/main/sections/add-nest/nest-failure/index.js
+++ b/public/app/screens/main/sections/add-nest/nest-failure/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./nest-failure.jsx');

--- a/public/app/screens/main/sections/add-nest/nest-failure/nest-failure.jsx
+++ b/public/app/screens/main/sections/add-nest/nest-failure/nest-failure.jsx
@@ -1,0 +1,25 @@
+var React = require('react');
+
+var SendNestAccessToken = React.createClass({
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  getInitialState: function getInitialState () {
+    return {
+      error: this.context.router.getCurrentParams().error
+    };
+  },
+
+  componentDidMount: function componentDidMount () {
+    this.props.onComplete();
+  },
+
+  render: function render () {
+    return (
+      <span>Cannot connect to nest API</span>
+    );
+  }
+});
+
+module.exports = SendNestAccessToken;

--- a/public/app/screens/main/sections/add-nest/send-nest-access-token/index.js
+++ b/public/app/screens/main/sections/add-nest/send-nest-access-token/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./send-nest-access-token.jsx');

--- a/public/app/screens/main/sections/add-nest/send-nest-access-token/send-nest-access-token.jsx
+++ b/public/app/screens/main/sections/add-nest/send-nest-access-token/send-nest-access-token.jsx
@@ -69,6 +69,7 @@ var SendNestAccessToken = React.createClass({
   onDeviceListStoreUpdate: function onDeviceListStoreUpdate () {
     // Look for nest web service among all things
     var nestService = _.find(this.state.devices, function isNestWebservice (device) {
+      // TODO: Use a more sophisticated way to identify the nest webservice device
       return (device.properties.name === 'WEBSERVICE oauth');
     });
     // Set nest access token as the service's property

--- a/public/app/screens/main/sections/add-nest/send-nest-access-token/send-nest-access-token.jsx
+++ b/public/app/screens/main/sections/add-nest/send-nest-access-token/send-nest-access-token.jsx
@@ -59,6 +59,8 @@ var SendNestAccessToken = React.createClass({
       case Actions.NEST_SERVICE_NOT_FOUND:
       case Actions.SEND_AUTH_TOKEN_FAILURE:
         return 'Cannot connect your nest account to your gateway';
+      case Actions.SEND_AUTH_TOKEN_SUCCESS:
+        return 'Your nest account is now connected to your gateway';
       default:
         return 'An unexpected error occurred';
     }

--- a/public/app/screens/main/sections/add-nest/send-nest-access-token/send-nest-access-token.jsx
+++ b/public/app/screens/main/sections/add-nest/send-nest-access-token/send-nest-access-token.jsx
@@ -1,0 +1,90 @@
+var React = require('react');
+var Reflux = require('reflux');
+var _ = require('lodash');
+
+var deviceListStore = require('stores/device-list');
+var devicesService = require('services/devices/devices-service');
+
+var Actions = {
+  RETRIEVING_DEVICES: 'RETRIEVING_DEVICES',
+  NEST_SERVICE_NOT_FOUND: 'NEST_SERVICE_NOT_FOUND',
+  SENDING_AUTH_TOKEN: 'SENDING_AUTH_TOKEN',
+  SEND_AUTH_TOKEN_SUCCESS: 'SEND_AUTH_TOKEN_SUCCESS',
+  SEND_AUTH_TOKEN_FAILURE: 'SEND_AUTH_TOKEN_FAILURE'
+};
+
+var SendNestAccessToken = React.createClass({
+  mixins: [
+    Reflux.connect(deviceListStore)
+  ],
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  getInitialState: function getInitialState () {
+    return {
+      accessToken: this.context.router.getCurrentParams().accessToken,
+      action: Actions.RETRIEVING_DEVICES
+    };
+  },
+
+  shouldComponentUpdate: function shouldComponentUpdate (nextProps, nextState) {
+    // Implicitly call the onComplete() handler when no more action is performed
+    switch (nextState.action) {
+      case Actions.NEST_SERVICE_NOT_FOUND:
+      case Actions.SEND_AUTH_TOKEN_SUCCESS:
+      case Actions.SEND_AUTH_TOKEN_FAILURE:
+        this.props.onComplete();
+    }
+    return true;
+  },
+
+  componentDidMount: function componentDidMount () {
+    this.listenTo(deviceListStore, this.onDeviceListStoreUpdate);
+  },
+
+  render: function render () {
+    return (
+      <span>{ this.messageForAction(this.state.action) }</span>
+    );
+  },
+
+  messageForAction: function messageForAction (action) {
+    // TODO: i18n
+    switch (action) {
+      case Actions.RETRIEVING_DEVICES:
+      case Actions.SENDING_AUTH_TOKEN:
+        return 'Connecting your nest account to your gateway...';
+      case Actions.NEST_SERVICE_NOT_FOUND:
+      case Actions.SEND_AUTH_TOKEN_FAILURE:
+        return 'Cannot connect your nest account to your gateway';
+      default:
+        return 'An unexpected error occurred';
+    }
+  },
+
+  onDeviceListStoreUpdate: function onDeviceListStoreUpdate () {
+    // Look for nest web service among all things
+    var nestService = _.find(this.state.devices, function isNestWebservice (device) {
+      return (device.properties.name === 'WEBSERVICE oauth');
+    });
+    // Set nest access token as the service's property
+    if (nestService) {
+      var action = nestService.actions['set-SETABLE-value'];
+      devicesService
+        .invokeDeviceAction(action, { value: this.state.accessToken })
+        .subscribe(
+          function onSuccess () {
+            this.setState({ action: Actions.SEND_AUTH_TOKEN_SUCCESS });
+          }.bind(this),
+          function onError () {
+            this.setState({ action: Actions.SEND_AUTH_TOKEN_FAILURE });
+          }.bind(this));
+    } else {
+      this.setState({ action: Actions.NEST_SERVICE_NOT_FOUND });
+    }
+  }
+});
+
+module.exports = SendNestAccessToken;

--- a/public/app/screens/main/sections/add-nest/send-nest-access-token/send-nest-access-token.jsx
+++ b/public/app/screens/main/sections/add-nest/send-nest-access-token/send-nest-access-token.jsx
@@ -29,17 +29,6 @@ var SendNestAccessToken = React.createClass({
     };
   },
 
-  shouldComponentUpdate: function shouldComponentUpdate (nextProps, nextState) {
-    // Implicitly call the onComplete() handler when no more action is performed
-    switch (nextState.action) {
-      case Actions.NEST_SERVICE_NOT_FOUND:
-      case Actions.SEND_AUTH_TOKEN_SUCCESS:
-      case Actions.SEND_AUTH_TOKEN_FAILURE:
-        this.props.onComplete();
-    }
-    return true;
-  },
-
   componentDidMount: function componentDidMount () {
     this.listenTo(deviceListStore, this.onDeviceListStoreUpdate);
   },
@@ -48,6 +37,19 @@ var SendNestAccessToken = React.createClass({
     return (
       <span>{ this.messageForAction(this.state.action) }</span>
     );
+  },
+
+  setAction: function setAction (action) {
+    if (this.state.action === action) {
+      return;
+    }
+    switch (action) {
+      case Actions.NEST_SERVICE_NOT_FOUND:
+      case Actions.SEND_AUTH_TOKEN_SUCCESS:
+      case Actions.SEND_AUTH_TOKEN_FAILURE:
+        this.props.onComplete();
+    }
+    this.setState( { action: action });
   },
 
   messageForAction: function messageForAction (action) {
@@ -70,7 +72,7 @@ var SendNestAccessToken = React.createClass({
     // Look for nest web service among all things
     var nestService = _.find(this.state.devices, function isNestWebservice (device) {
       // TODO: Use a more sophisticated way to identify the nest webservice device
-      return (device.properties.name === 'WEBSERVICE oauth');
+      return device.properties.name === 'WEBSERVICE oauth';
     });
     // Set nest access token as the service's property
     if (nestService) {
@@ -79,13 +81,13 @@ var SendNestAccessToken = React.createClass({
         .invokeDeviceAction(action, { value: this.state.accessToken })
         .subscribe(
           function onSuccess () {
-            this.setState({ action: Actions.SEND_AUTH_TOKEN_SUCCESS });
+            this.setAction( Actions.SEND_AUTH_TOKEN_SUCCESS );
           }.bind(this),
           function onError () {
-            this.setState({ action: Actions.SEND_AUTH_TOKEN_FAILURE });
+            this.setAction( Actions.SEND_AUTH_TOKEN_FAILURE );
           }.bind(this));
     } else {
-      this.setState({ action: Actions.NEST_SERVICE_NOT_FOUND });
+      this.setAction( Actions.NEST_SERVICE_NOT_FOUND );
     }
   }
 });

--- a/public/app/screens/main/sections/add-nest/send-nest-access-token/style.scss
+++ b/public/app/screens/main/sections/add-nest/send-nest-access-token/style.scss
@@ -1,0 +1,1 @@
+@import "components-theme";


### PR DESCRIPTION
After returning from nest authentication the control center redirects either to `#/devices/add/nest/success/<accessToken>` or `#/devices/add/nest/error/<code>`. In case of success the "nest webservice device" will be looked up among all household devices and the nest access token is assigned to it as a "set property" request. The user is presented any success/error message. The complete UI flow for connecting the nest account is however only a first draft and thus subject to change.

@DaQuirm @ghophp 