### PR TITLE
Fix/setup app link

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "classname": "0.0.0",
     "es5-shim": "^4.1.0",
     "es6-promise": "^2.0.1",
+    "platform": "^1.3.0",
     "react": "^0.13.1",
     "react-router": "^0.13.2",
     "reflux": "^0.2.7",

--- a/public/app/common/helpers/config/index.coffee
+++ b/public/app/common/helpers/config/index.coffee
@@ -1,0 +1,18 @@
+platform = require 'platform'
+
+Helpers =
+
+  getSetupAppUrl: ->
+    isOSX = ->
+      userAgentString = navigator.userAgent
+      environment = platform.parse userAgentString
+      /OS X/.test environment.os.family
+
+    if isOSX platform
+      window.yetu.config.setupDownloadUrlMac
+    else
+      window.yetu.config.setupDownloadUrlWin
+
+module.exports = Helpers
+
+

--- a/public/app/common/helpers/config/test/config-helpers.mock.coffee
+++ b/public/app/common/helpers/config/test/config-helpers.mock.coffee
@@ -1,0 +1,9 @@
+module.exports =
+
+  config:
+    setupDownloadUrlWin: 'win-url.exe'
+    setupDownloadUrlMac: 'mac-url.dmg'
+
+  UserAgentString:
+    WINDOWS: 'Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)'
+    OSX: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36'

--- a/public/app/common/helpers/config/test/config-helpers.spec.coffee
+++ b/public/app/common/helpers/config/test/config-helpers.spec.coffee
@@ -1,0 +1,29 @@
+ConfigHelpers = require '..'
+mock = require './config-helpers.mock.coffee'
+
+describe 'ConfigHelpers', ->
+
+  describe 'getSetupAppUrl', ->
+
+    config = null
+    userAgent = null
+
+    beforeEach ->
+      # mock config
+      config = window.yetu.config
+      window.yetu.config = mock.config
+      userAgent = navigator.userAgent
+
+    afterEach ->
+      navigator.userAgent = userAgent
+      window.yetu.config = config
+
+    it 'returns the url pointing to the Windows version of the setup app on Windows', ->
+      navigator.userAgent = mock.UserAgentString.WINDOWS
+      url = do ConfigHelper.getSetupAppUrl
+      expect(url).toEqual window.yetu.config.setupDownloadUrlWin
+
+    it 'returns the url pointing to the OS X version of the setup app on OS X', ->
+      navigator.userAgent = mock.UserAgentString.OSX
+      url = do ConfigHelper.getSetupAppUrl
+      expect(url).toEqual window.yetu.config.setupDownloadUrlMac

--- a/public/app/project-setup/test/config.stub.js
+++ b/public/app/project-setup/test/config.stub.js
@@ -1,0 +1,4 @@
+// use empty object when running tests as the config
+// object is not passed in the testing environment
+window.yetu = window.yetu || {};
+window.yetu.config = window.yetu.config || {};

--- a/public/app/project-setup/test/karma.conf.js
+++ b/public/app/project-setup/test/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function (config) {
     frameworks: ['jasmine', 'sinon'],
     files: [
       './app/project-setup/test/phantomjs-bind.polyfill.js',
+      './app/project-setup/test/config.stub.js',
       './**/*.spec.js*'
     ],
 

--- a/public/app/screens/main/sections/gateway-details/gateway-details.jsx
+++ b/public/app/screens/main/sections/gateway-details/gateway-details.jsx
@@ -39,7 +39,7 @@ var DeviceDetails = React.createClass({
             <h5>Get setup app</h5>
           </div>
           <div className='columns medium-4'>
-            <a className='link' href='#'>Download setup app</a>
+            <a className='link' href={gateway.setupAppUrl}>Download setup app</a>
           </div>
           <div className='columns medium-6'></div>
         </div>

--- a/public/app/stores/gateway/gateway-store.js
+++ b/public/app/stores/gateway/gateway-store.js
@@ -1,4 +1,6 @@
 var Reflux = require('reflux');
+var _ = require('lodash');
+var platform = require('platform');
 
 var deviceActions = require('actions/device');
 var gatewayService = require('services/devices/gateway-service');
@@ -9,24 +11,45 @@ module.exports = Reflux.createStore({
     this.onFetchGateway();
   },
 
+  getSetupAppUrl: function getSetupAppUrl () {
+
+    function isOSX () {
+      var userAgentString = navigator.userAgent;
+      var environment = platform.parse(userAgentString);
+      return /OS X/.test(environment.os.family);
+    }
+
+    if (isOSX(platform)) {
+      return window.yetu.config.setupDownloadUrlMac;
+    } else {
+      return window.yetu.config.setupDownloadUrlWin;
+    }
+  },
+
+  createModel: function createModel (data) {
+    return _.assign(data, {
+      setupAppUrl: this.getSetupAppUrl()
+    });
+  },
+
   getInitialState: function getInitialState () {
     // fetch gateway status on each page view
     // as we don't have polling
     this.onFetchGateway();
     return {
-      model: {}
+      model: this.createModel({})
     };
   },
 
   onFetchGateway: function onFetchGateway () {
-    var self = this;
     gatewayService.fetchGatewayInfo()
-      .subscribe(self.updateModel.bind(self), self.updateError.bind(self));
+      .subscribe(this.updateModel, this.updateError);
   },
 
-  updateModel: function updateModel (gateway) {
+  updateModel: function updateModel (gatewayData) {
+    var model = this.createModel(gatewayData);
     this.trigger({
-      model: gateway
+      model: model
     });
   },
 

--- a/public/app/stores/gateway/gateway-store.js
+++ b/public/app/stores/gateway/gateway-store.js
@@ -1,7 +1,7 @@
 var Reflux = require('reflux');
 var _ = require('lodash');
-var platform = require('platform');
 
+var ConfigHelpers = require('helpers/config');
 var deviceActions = require('actions/device');
 var gatewayService = require('services/devices/gateway-service');
 
@@ -11,24 +11,9 @@ module.exports = Reflux.createStore({
     this.onFetchGateway();
   },
 
-  getSetupAppUrl: function getSetupAppUrl () {
-
-    function isOSX () {
-      var userAgentString = navigator.userAgent;
-      var environment = platform.parse(userAgentString);
-      return /OS X/.test(environment.os.family);
-    }
-
-    if (isOSX(platform)) {
-      return window.yetu.config.setupDownloadUrlMac;
-    } else {
-      return window.yetu.config.setupDownloadUrlWin;
-    }
-  },
-
   createModel: function createModel (data) {
     return _.assign(data, {
-      setupAppUrl: this.getSetupAppUrl()
+      setupAppUrl: ConfigHelpers.getSetupAppUrl()
     });
   },
 


### PR DESCRIPTION
Use [platform.js](https://github.com/bestiejs/platform.js/) to detect OS X/Windows and use the appropriate Setup App link from config. 

See line comments below for more details.

@larsblumberg @ghophp